### PR TITLE
ファイルアップロードで post_max_size を超えると $_POSTが空っぽになる症状対策

### DIFF
--- a/Controller/Component/FileUploadComponent.php
+++ b/Controller/Component/FileUploadComponent.php
@@ -37,6 +37,25 @@ class FileUploadComponent extends Component {
 	}
 
 /**
+ * Called after the Controller::beforeFilter() and before the controller action
+ *
+ * @param Controller $controller Controller with components to startup
+ * @return void
+ */
+	public function startup(Controller $controller) {
+		// ファイルアップロード等で post_max_size を超えると $_POSTが空っぽになるため、このタイミングでエラー表示
+		$contentLength = Hash::get($_SERVER, 'CONTENT_LENGTH');
+		if ($contentLength > CakeNumber::fromReadableSize(ini_get('post_max_size'))) {
+			$message = __d('files', 'FileUpload.post_max_size.over');
+			$controller->NetCommons->setFlashNotification($message, array(
+				'class' => 'danger',
+				'interval' => NetCommonsComponent::ALERT_VALIDATE_ERROR_INTERVAL,
+			));
+			$controller->redirect($controller->referer());
+		}
+	}
+
+/**
  * アップロードされたテンポラリファイルを得る。
  *
  * @param string $fieldName フォームのフィールド名

--- a/Locale/files.pot
+++ b/Locale/files.pot
@@ -22,3 +22,6 @@ msgstr ""
 
 msgid "It is upload disabled file format"
 msgstr ""
+
+msgid "Total file size uploaded to the %s, exceeded the limit. The limit is %s(%s left)."
+msgstr ""

--- a/Locale/jpn/LC_MESSAGES/files.po
+++ b/Locale/jpn/LC_MESSAGES/files.po
@@ -27,3 +27,6 @@ msgstr "アップロード不可のファイル形式です"
 
 msgid "Total file size uploaded to the %s, exceeded the limit. The limit is %s(%s left)."
 msgstr "%sにアップロードしたファイルサイズの合計が大きすぎます。合計%s(残り:%s)までしか使用できません。"
+
+msgid "FileUpload.post_max_size.over"
+msgstr "アップロードファイルが大きすぎて php.ini の post_max_size ディレクティブの値を超えたため、入力内容が消えました。管理者にご相談ください"


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/539
