### PR TITLE
AttachmentビヘイビアにsizeFieldName オプションを追加。

### DIFF
--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -112,8 +112,12 @@ class AttachmentBehavior extends ModelBehavior {
 						$model->data[$model->alias][$fileNameFieldName] =
 							$fileData['name'];
 					}
-					//if ($model->hasField(''))
-					// ε(　　　　 v ﾟωﾟ)　＜ サイズフィールドをうめる
+					// サイズフィールドをうめる
+					$sizeFieldName = Hash::get($filedOptions, 'sizeFieldName');
+					if ($sizeFieldName) {
+						$model->data[$model->alias][$sizeFieldName] =
+							$fileData['size'];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
元モデルのsizeFileldNameで指定されたフィールドにファイルサイズを保存するようにした
