### PR TITLE
CsvFileWriterで、変換する文字をto_encoding,from_encodingをoptionsにセットすることで設定できる…

### DIFF
--- a/Utility/CsvFileWriter.php
+++ b/Utility/CsvFileWriter.php
@@ -56,11 +56,15 @@ class CsvFileWriter extends TemporaryFile {
 		}
 		fclose($fp);
 
-		$convertLine = mb_convert_encoding(
-			$csvLine,
-			$this->_options['to_encoding'],
-			$this->_options['from_encoding']
-		);
+		if ($this->_options['to_encoding'] !== $this->_options['from_encoding']) {
+			$convertLine = mb_convert_encoding(
+				$csvLine,
+				$this->_options['to_encoding'],
+				$this->_options['from_encoding']
+			);
+		} else {
+			$convertLine = $csvLine;
+		}
 		$this->append($convertLine);
 	}
 

--- a/Utility/CsvFileWriter.php
+++ b/Utility/CsvFileWriter.php
@@ -25,6 +25,14 @@ class CsvFileWriter extends TemporaryFile {
 	public function __construct($options = array()) {
 		$folderPath = Hash::get($options, 'folder', null);
 		parent::__construct($folderPath);
+
+		if (! isset($options['to_encoding'])) {
+			$options['to_encoding'] = 'SJIS-win';
+		}
+		if (! isset($options['from_encoding'])) {
+			$options['from_encoding'] = 'UTF-8';
+		}
+
 		$this->_options = $options;
 		if (Hash::get($this->_options, 'header', false)) {
 			// headerオプションが指定されてたらヘッダ出力
@@ -47,8 +55,12 @@ class CsvFileWriter extends TemporaryFile {
 			$csvLine .= fgets($fp);
 		}
 		fclose($fp);
-		// ε(　　　　 v ﾟωﾟ)　＜ SJIS-win決め打ちなのをなんとかしたいか
-		$convertLine = mb_convert_encoding($csvLine, 'SJIS-win', 'UTF-8');
+
+		$convertLine = mb_convert_encoding(
+			$csvLine,
+			$this->_options['to_encoding'],
+			$this->_options['from_encoding']
+		);
 		$this->append($convertLine);
 	}
 


### PR DESCRIPTION
CsvFileWriterで、変換する文字をto_encoding,from_encodingをoptionsにセットすることで設定できるように修正