### PR TITLE
fix: #pull/114 のPullReqPullReqをマージしたことによりMac Safariでファイル名が文字化けする。

### DIFF
--- a/Controller/Component/DownloadComponent.php
+++ b/Controller/Component/DownloadComponent.php
@@ -192,7 +192,7 @@ class DownloadComponent extends Component {
 				$downloadFileName = $options['name'];
 			}
 			$content = 'attachment;';
-			$content .= 'filename*=UTF-8\'\'' . $downloadFileName;
+			$content .= 'filename*=UTF-8\'\'' . rawurlencode($downloadFileName);
 			$this->_controller->response->header('Content-Disposition', $content);
 
 			// name, downloadが入っているとCake側処理により文字化けが発生する


### PR DESCRIPTION
https://github.com/NetCommons3/Files/pull/114 このPullReqをマージしたことによりMac Safariでファイル名が文字化けする。また、Chromeでも似た現象。

問い合わせ）https://www.netcommons.org/bbses/bbs_articles/view/778/98cfeeb1857a7df85c1cdb160b61f3c9?frame_id=199
https://github.com/NetCommons3/NetCommons3/issues/1433