### PR TITLE
fix: ファイルの添付と削除を同時に実行するとinsert時にエラーになるのでバリデーション追加

### DIFF
--- a/Locale/jpn/LC_MESSAGES/files.po
+++ b/Locale/jpn/LC_MESSAGES/files.po
@@ -43,3 +43,5 @@ msgstr "%sにアップロードしたファイルサイズの合計が大きす�
 msgid "Please specify the file"
 msgstr "ファイルを指定してください"
 
+msgid "Cannot attach and delete a file at the same time."
+msgstr "ファイル添付と削除を同時に行うことはできません。"

--- a/Model/Behavior/AttachmentBehavior.php
+++ b/Model/Behavior/AttachmentBehavior.php
@@ -384,6 +384,12 @@ class AttachmentBehavior extends ModelBehavior {
 		$model->validate[$field]['size'] = [
 			'rule' => 'validateRoomFileSizeLimit',
 		];
+
+		// removeをファイルアップロードと同時指定しないようにするバリデータ
+		$model->validate[$field]['remove'] = [
+			'rule' => ['validateRemoveWithoutUploading'],
+			'message' => __d('files', 'Cannot attach and delete a file at the same time.')
+		];
 	}
 
 /**

--- a/Model/Behavior/UploadFileValidateBehavior.php
+++ b/Model/Behavior/UploadFileValidateBehavior.php
@@ -124,6 +124,27 @@ EOF;
 	}
 
 /**
+ * validateRemove
+ *
+ * @param Model $model Model
+ * @param array $check バリデートする値
+ * @return bool
+ */
+	public function validateRemoveWithoutUploading(Model $model, $check) : bool {
+		$fieldName = $this->_getField($check);
+		// ファイルの添付と同時に削除は不可
+		$remove = $model->data[$model->alias][$fieldName]['remove'] ?? null;
+		if (!$remove) {
+			return true;
+		}
+		$uploadError = $model->data[$model->alias][$fieldName]['error']?? null;
+		if ($uploadError === null) {
+			return true;
+		}
+		return $uploadError === UPLOAD_ERR_NO_FILE;
+	}
+
+/**
  * Returns the field to check
  *
  * @param array $check array of validation data


### PR DESCRIPTION
ファイルの添付と削除を同時に実行するとinsert時にエラーになるので、削除していとファイルアップロードを同時に行えないようにバリデーションを追加した。 Refs https://github.com/researchmap/RmNetCommons3/issues/2583